### PR TITLE
Fix bug: crash if host is invalid

### DIFF
--- a/main.go
+++ b/main.go
@@ -82,7 +82,7 @@ func check(host, port string, days int, verbose bool) error {
 		InsecureSkipVerify: true,
 	})
 	if err != nil {
-
+            return err
 	}
 
 	defer conn.Close()


### PR DESCRIPTION
If trying an invalid host, it will crash with the following log:

> panic: runtime error: invalid memory address or nil pointer dereference
> 	panic: runtime error: invalid memory address or nil pointer dereference
> [signal SIGSEGV: segmentation violation code=0x1 addr=0x330 pc=0x11702f6]
> 
> goroutine 7 [running]:
> crypto/tls.(*Conn).Close(0x0, 0xc000114000, 0x18)
> 	/usr/local/Cellar/go/1.11/libexec/src/crypto/tls/conn.go:1199 +0x26
> panic(0x11ed6a0, 0x1398360)
> 	/usr/local/Cellar/go/1.11/libexec/src/runtime/panic.go:513 +0x1b9
> crypto/tls.(*Conn).Handshake(0x0, 0x0, 0x0)
> 	/usr/local/Cellar/go/1.11/libexec/src/crypto/tls/conn.go:1258 +0x2e
> main.check(0xc0000184c0, 0x14, 0x1224bca, 0x3, 0x1e, 0x0, 0x0, 0x0)
> 	/Users/yftung/git/certwatcher/main.go:90 +0x191
> main.main.func1(0xc0000163c0, 0xc0000184c0, 0x14, 0xc0000162e0, 0xc0000162e8, 0xc0000184d4, 0x6, 0xc0000b2000)
> 	/Users/yftung/git/certwatcher/main.go:64 +0xae
> created by main.main
> 	/Users/yftung/git/certwatcher/main.go:62 +0x63c

Adding this error handling fixes this issue.